### PR TITLE
[BT-2770] Track Learner Duration

### DIFF
--- a/index.php
+++ b/index.php
@@ -25,7 +25,7 @@
 
 use core\session\manager;
 
-require('../../config.php');
+require($_SERVER['DOCUMENT_ROOT'] . '/../config.php');
 global $CFG;
 require_once($CFG->dirroot . '/blocks/timestat/locallib.php');
 require_once($CFG->libdir . '/adminlib.php');


### PR DESCRIPTION
The existing `require('../../config.php');` line does not work in our SDO LMS environment for two reasons:
1. We are using Moodle 5+ which moved the blocks into a Public directory, making the relative path incorrect (it would need to go one level higher).
2. Our contrib and custom code are copied into an SDO directory in our Docker container and then symlinked into the /var/www/html directory that the moodle code is served from. Using `require()` in the original fashion ends up attempting to reference the `config.php` from the physical SDO location, but it does not live there as it exists directly in `/var/www/html`.

We are forking the original contrib repo and modifying the code to use the PHP Superglobal for the Web Server Document Root to direct us to the config.php file.